### PR TITLE
Re-upload the .po file upon every step to keep the process stateless

### DIFF
--- a/gp-import-export.php
+++ b/gp-import-export.php
@@ -10,7 +10,8 @@ require_once( dirname(__FILE__) .'/includes/router.php' );
 
 class GP_Import_Export extends GP_Plugin {
 
-	var $id = 'importer';
+	public $id = 'importer';
+	public $use_iframe = true;
 
 	public function __construct() {
 		parent::__construct();

--- a/gp-import-export.php
+++ b/gp-import-export.php
@@ -11,7 +11,6 @@ require_once( dirname(__FILE__) .'/includes/router.php' );
 class GP_Import_Export extends GP_Plugin {
 
 	public $id = 'importer';
-	public $use_iframe = true;
 
 	public function __construct() {
 		parent::__construct();

--- a/includes/router.php
+++ b/includes/router.php
@@ -152,7 +152,7 @@ class GP_Route_Import_export extends GP_Route_Main {
 		$step = gp_post( 'importer-step', '1' );
 
 		$pofiles = false;
-		if ( $step === 1 || GP::$plugins->import_export->use_iframe ) {
+		if ( $step === 1 || gp_post( 'use-iframe' ) ) {
 			$pofiles = $this->process_archive_file( $project );
 		}
 

--- a/includes/router.php
+++ b/includes/router.php
@@ -151,10 +151,8 @@ class GP_Route_Import_export extends GP_Route_Main {
 
 		$step = gp_post( 'importer-step', '1' );
 
-		$pofiles = false;
-		if ( $step === 1 || gp_post( 'use-iframe' ) ) {
-			$pofiles = $this->process_archive_file( $project );
-		}
+		// process the archive file upon each step because it is uploaded on every step because of the server-farm infrastructure
+		$pofiles = $this->process_archive_file( $project );
 
 		switch( $step ) {
 			case 1:
@@ -200,24 +198,24 @@ class GP_Route_Import_export extends GP_Route_Main {
 		$slug = preg_replace( '/\.zip$/', '', $filename );
 
 		$working_directory = '/bulk-importer-' . $slug;
-		$working_path = sys_get_temp_dir() . $working_directory;
+		$this->working_path = sys_get_temp_dir() . $working_directory;
 
 		// Make sure we have a fresh working directory.
-		if ( file_exists( $working_path ) ) {
-			GP_Import_Export::rrmdir( $working_path );
+		if ( file_exists( $this->working_path ) ) {
+			GP_Import_Export::rrmdir( $this->working_path );
 		}
 
-		mkdir( $working_path );
+		mkdir( $this->working_path );
 
 		$zip = new ZipArchiveExtended;
 		if ( $zip->open( $_FILES['import-file']['tmp_name'] ) ) {
-			$zip->extractToFlatten( $working_path );
+			$zip->extractToFlatten( $this->working_path );
 			$zip->close();
 		}
 
-		$pofiles = glob("$working_path/*.po");
+		$pofiles = glob( $this->working_path . '/*.po' );
 		if ( empty( $pofiles ) ) {
-			GP_Import_Export::rrmdir( $working_path );
+			GP_Import_Export::rrmdir( $this->working_path );
 			$this->redirect_with_error( __( 'No PO files found in zip archive' ) );
 		}
 
@@ -226,15 +224,7 @@ class GP_Route_Import_export extends GP_Route_Main {
 
 	function confirm_selections( $project, $pofiles = false ) {
 
-		$working_directory = gp_post( 'working-directory' );
-		$working_path = sys_get_temp_dir() . $working_directory;
-
-		if ( $working_path !== realpath( $working_path ) ) {
-			$this->die_with_error( 'Error.' );
-		}
-
 		$to_import = array();
-		if ( ! $pofiles ) $pofiles = glob( "$working_path/*.po" );
 		foreach( $pofiles as $po_file ) {
 			$target_set = gp_post( basename( $po_file, '.po') );
 			if ( $target_set  ) {
@@ -258,13 +248,6 @@ class GP_Route_Import_export extends GP_Route_Main {
 
 	function process_imports( $project, $pofiles = false ) {
 
-		$working_directory = gp_post( 'working-directory' );
-		$working_path = '/tmp' . $working_directory;
-
-		if ( $working_path !== realpath( $working_path ) ) {
-			$this->die_with_error( 'Error.' );
-		}
-
 		if ( 'no' == gp_post( 'overwrite', 'yes' ) ) {
 			add_filter( 'translation_set_import_over_existing', '__return_false' );
 		}
@@ -275,7 +258,6 @@ class GP_Route_Import_export extends GP_Route_Main {
 			});
 		}
 
-		if ( ! $pofiles ) $pofiles = glob( "$working_path/*.po" );
 		foreach( $pofiles as $po_file ) {
 			$target_set = gp_post( basename( $po_file, '.po') );
 			if ( $target_set  ) {
@@ -299,8 +281,10 @@ class GP_Route_Import_export extends GP_Route_Main {
 		$this->notices = array( implode('<br>', $this->notices ) );
 		$this->errors = array( implode('<br>', $this->errors ) );
 
-		//cleanup
-		GP_Import_Export::rrmdir( $working_path );
+		// cleanup
+		if ( $this->working_path ) {
+			GP_Import_Export::rrmdir( $this->working_path );
+		}
 
 		$this->redirect();
 	}

--- a/templates/importer-confirmation.php
+++ b/templates/importer-confirmation.php
@@ -39,7 +39,7 @@ gp_tmpl_header();
 		</dl>
 	</form>
 
-	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
+	<?php if ( gp_post( 'use-iframe' ) ): ?>
 		<script type="text/javascript">
 			parent.document.getElementById('step2').style.display = 'none';
 			parent.document.getElementById('step3').innerHTML = document.getElementById('step3').innerHTML;

--- a/templates/importer-confirmation.php
+++ b/templates/importer-confirmation.php
@@ -10,7 +10,6 @@ gp_tmpl_header();
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
 	<form action="" method="post" enctype="multipart/form-data" id="step3">
 	<input type="hidden" name="importer-step" value="3">
-	<input type="hidden" name="working-directory" value="<?php echo esc_attr( $working_directory );?>">
 		<dl>
 			<dt><?php _e( 'Select Sets' ); ?></dt>
 			<dd>
@@ -39,13 +38,11 @@ gp_tmpl_header();
 		</dl>
 	</form>
 
-	<?php if ( gp_post( 'use-iframe' ) ): ?>
-		<script type="text/javascript">
-			parent.document.getElementById('step2').style.display = 'none';
-			parent.document.getElementById('step3').innerHTML = document.getElementById('step3').innerHTML;
-			parent.document.getElementById('step1form').target = "top";
-		</script>
-	<?php endif; ?>
+	<script type="text/javascript">
+		parent.document.getElementById('step2').style.display = 'none';
+		parent.document.getElementById('step3').innerHTML = document.getElementById('step3').innerHTML;
+		parent.document.getElementById('step1form').target = "top";
+	</script>
 
 
 <?php gp_tmpl_footer();

--- a/templates/importer-confirmation.php
+++ b/templates/importer-confirmation.php
@@ -8,7 +8,7 @@ gp_tmpl_header();
 ?>
 
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
-	<form action="" method="post" enctype="multipart/form-data">
+	<form action="" method="post" enctype="multipart/form-data" id="step3">
 	<input type="hidden" name="importer-step" value="3">
 	<input type="hidden" name="working-directory" value="<?php echo esc_attr( $working_directory );?>">
 		<dl>
@@ -38,5 +38,14 @@ gp_tmpl_header();
 			<dt><input type="submit" value="<?php echo esc_attr( __( 'Import' ) ); ?>"></dt>
 		</dl>
 	</form>
+
+	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
+		<script type="text/javascript">
+			parent.document.getElementById('step2').style.display = 'none';
+			parent.document.getElementById('step3').innerHTML = document.getElementById('step3').innerHTML;
+			parent.document.getElementById('step1form').target = "top";
+		</script>
+	<?php endif; ?>
+
 
 <?php gp_tmpl_footer();

--- a/templates/importer-files.php
+++ b/templates/importer-files.php
@@ -48,7 +48,7 @@ function get_key_to_be_selected( $name_and_id, $options ) {
 		</dl>
 	</form>
 
-	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
+	<?php if ( gp_post( 'use-iframe' ) ): ?>
 		<script type="text/javascript">
 			parent.document.getElementById('step1').style.display = 'none';
 			parent.document.getElementById('step2').innerHTML = document.getElementById('step2').innerHTML;

--- a/templates/importer-files.php
+++ b/templates/importer-files.php
@@ -30,9 +30,9 @@ function get_key_to_be_selected( $name_and_id, $options ) {
 ?>
 
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
-	<form action="" method="post" enctype="multipart/form-data">
-	<input type="hidden" name="importer-step" value="2">
-	<input type="hidden" name="working-directory" value="<?php echo esc_attr( $working_directory );?>">
+	<form action="" method="post" enctype="multipart/form-data" id="step2">
+		<input type="hidden" name="importer-step" value="2">
+		<input type="hidden" name="working-directory" value="<?php echo esc_attr( $working_directory );?>">
 		<dl>
 			<dt><?php _e( 'Select Sets' ); ?></dt>
 			<dd>
@@ -47,5 +47,12 @@ function get_key_to_be_selected( $name_and_id, $options ) {
 			<dt><input type="submit" value="<?php echo esc_attr( __('Review') ); ?>"></dt>
 		</dl>
 	</form>
+
+	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
+		<script type="text/javascript">
+			parent.document.getElementById('step1').style.display = 'none';
+			parent.document.getElementById('step2').innerHTML = document.getElementById('step2').innerHTML;
+		</script>
+	<?php endif; ?>
 
 <?php gp_tmpl_footer();

--- a/templates/importer-files.php
+++ b/templates/importer-files.php
@@ -32,7 +32,6 @@ function get_key_to_be_selected( $name_and_id, $options ) {
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
 	<form action="" method="post" enctype="multipart/form-data" id="step2">
 		<input type="hidden" name="importer-step" value="2">
-		<input type="hidden" name="working-directory" value="<?php echo esc_attr( $working_directory );?>">
 		<dl>
 			<dt><?php _e( 'Select Sets' ); ?></dt>
 			<dd>
@@ -48,11 +47,9 @@ function get_key_to_be_selected( $name_and_id, $options ) {
 		</dl>
 	</form>
 
-	<?php if ( gp_post( 'use-iframe' ) ): ?>
-		<script type="text/javascript">
-			parent.document.getElementById('step1').style.display = 'none';
-			parent.document.getElementById('step2').innerHTML = document.getElementById('step2').innerHTML;
-		</script>
-	<?php endif; ?>
+	<script type="text/javascript">
+		parent.document.getElementById('step1').style.display = 'none';
+		parent.document.getElementById('step2').innerHTML = document.getElementById('step2').innerHTML;
+	</script>
 
 <?php gp_tmpl_footer();

--- a/templates/importer.php
+++ b/templates/importer.php
@@ -8,13 +8,34 @@ gp_tmpl_header();
 ?>
 
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
-	<form action="" method="post" enctype="multipart/form-data">
+	<form action="" method="post" enctype="multipart/form-data"<?php if ( GP::$plugins->import_export->use_iframe ) echo ' target="tempframe"'; ?> id="step1form">
+		<div id="inner-error" class="error" style="display: none"></div>
 		<input type="hidden" name="importer-step" value="1">
-		<dl>
+		<dl id="step1">
 			<dt><label for="import-file"><?php _e( 'Import File:' ); ?></label></dt>
 			<dd><input type="file" name="import-file" id="import-file" /></dd>
 			<dt><input type="submit" value="<?php echo esc_attr( __( 'Import' ) ); ?>"></dt>
 		</dl>
+		<dl id="step2">
+		</dl>
+		<dl id="step3">
+		</dl>
 	</form>
+
+	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
+		<iframe name="tempframe" width="200" height="200" style="display: none"></iframe>
+		<script type="text/javascript">
+		setInterval( function() {
+			var error = tempframe.jQuery('.error');
+			if ( error.length > 0 ) {
+				jQuery('#inner-error').html( error.html() ).show();
+				jQuery('html, body').animate({
+				    scrollTop: jQuery("#inner-error").offset().top
+				}, 200);
+			} else {
+				jQuery('#inner-error').hide();
+			}
+		}, 1000); </script>
+	<?php endif; ?>
 
 <?php gp_tmpl_footer();

--- a/templates/importer.php
+++ b/templates/importer.php
@@ -14,8 +14,6 @@ gp_tmpl_header();
 		<dl id="step1">
 			<dt><label for="import-file"><?php _e( 'Import File:' ); ?></label></dt>
 			<dd><input type="file" name="import-file" id="import-file" /></dd>
-			<dt><?php _e( 'Advanced' ); ?></dt>
-			<dd><label><input type="checkbox" name="use-iframe" value="1" id="use-iframe-checkbox" <?php if ( gp_post( 'use-iframe' ) ) echo ' checked="checked"'; ?>/> <?php _e( 'Re-submit file on every step' ); ?></label></dd>
 			<dt><input type="submit" value="<?php echo esc_attr( __( 'Import' ) ); ?>"></dt>
 		</dl>
 		<dl id="step2">
@@ -29,26 +27,10 @@ gp_tmpl_header();
 	<script type="text/javascript">
 	var updateErrorsInterval;
 	jQuery( function() {
-		if ( jQuery( '#use-iframe-checkbox' ).is( ':checked' ) ) {
-			enableIframe();
-		}
-		jQuery( '#use-iframe-checkbox' ).on( 'change', function() {
-			if ( this.checked ) {
-				enableIframe();
-			} else {
-				disableIframe();
-			}
-		});
-	} );
-	function enableIframe() {
 		jQuery( '#tempframe-holder' ).html( '<iframe name="tempframe"></iframe>' );
 		jQuery( '#step1form' ).attr( 'target', 'tempframe' );
 		updateErrorsInterval = setInterval( updateErrors, 1000 );
-	}
-	function disableIframe() {
-		jQuery( '#step1form' ).attr( 'target', null );
-		clearInterval( updateErrorsInterval );
-	}
+	}) ;
 	function updateErrors() {
 		if ( typeof window.tempframe === 'undefined' || typeof window.tempframe.jQuery === 'undefined' ) {
 			return false;

--- a/templates/importer.php
+++ b/templates/importer.php
@@ -8,12 +8,14 @@ gp_tmpl_header();
 ?>
 
 	<h2><?php _e('Bulk Import Translations'); ?></h2>
-	<form action="" method="post" enctype="multipart/form-data"<?php if ( GP::$plugins->import_export->use_iframe ) echo ' target="tempframe"'; ?> id="step1form">
+	<form action="" method="post" enctype="multipart/form-data" id="step1form">
 		<div id="inner-error" class="error" style="display: none"></div>
 		<input type="hidden" name="importer-step" value="1">
 		<dl id="step1">
 			<dt><label for="import-file"><?php _e( 'Import File:' ); ?></label></dt>
 			<dd><input type="file" name="import-file" id="import-file" /></dd>
+			<dt><?php _e( 'Advanced' ); ?></dt>
+			<dd><label><input type="checkbox" name="use-iframe" value="1" id="use-iframe-checkbox" <?php if ( gp_post( 'use-iframe' ) ) echo ' checked="checked"'; ?>/> <?php _e( 'Re-submit file on every step' ); ?></label></dd>
 			<dt><input type="submit" value="<?php echo esc_attr( __( 'Import' ) ); ?>"></dt>
 		</dl>
 		<dl id="step2">
@@ -22,20 +24,45 @@ gp_tmpl_header();
 		</dl>
 	</form>
 
-	<?php if ( GP::$plugins->import_export->use_iframe ): ?>
-		<iframe name="tempframe" width="200" height="200" style="display: none"></iframe>
-		<script type="text/javascript">
-		setInterval( function() {
-			var error = tempframe.jQuery('.error');
-			if ( error.length > 0 ) {
-				jQuery('#inner-error').html( error.html() ).show();
-				jQuery('html, body').animate({
-				    scrollTop: jQuery("#inner-error").offset().top
-				}, 200);
+	<div id="tempframe-holder" style="display: none"></div>
+
+	<script type="text/javascript">
+	var updateErrorsInterval;
+	jQuery( function() {
+		if ( jQuery( '#use-iframe-checkbox' ).is( ':checked' ) ) {
+			enableIframe();
+		}
+		jQuery( '#use-iframe-checkbox' ).on( 'change', function() {
+			if ( this.checked ) {
+				enableIframe();
 			} else {
-				jQuery('#inner-error').hide();
+				disableIframe();
 			}
-		}, 1000); </script>
-	<?php endif; ?>
+		});
+	} );
+	function enableIframe() {
+		jQuery( '#tempframe-holder' ).html( '<iframe name="tempframe"></iframe>' );
+		jQuery( '#step1form' ).attr( 'target', 'tempframe' );
+		updateErrorsInterval = setInterval( updateErrors, 1000 );
+	}
+	function disableIframe() {
+		jQuery( '#step1form' ).attr( 'target', null );
+		clearInterval( updateErrorsInterval );
+	}
+	function updateErrors() {
+		if ( typeof window.tempframe === 'undefined' || typeof window.tempframe.jQuery === 'undefined' ) {
+			return false;
+		}
+		var error = window.tempframe.jQuery('.error');
+		if ( error.length > 0 ) {
+			jQuery('#inner-error').html( error.html() ).show();
+			jQuery('html, body').animate({
+			    scrollTop: jQuery("#inner-error").offset().top
+			}, 200);
+		} else {
+			jQuery('#inner-error').hide();
+		}
+	}
+	</script>
 
 <?php gp_tmpl_footer();


### PR DESCRIPTION
This enables the use of the plugin on server farms where requests for step 1 might land on another server than requests for step 2.

This is currently configured with a variable `$use_iframe` in `gp-import-export.php`. Probably we should not keep it there and make it configurable but I am unsure where to do that.

How it is done: The forms POST into an iframe which sends back its content via JavaScript and extends the existing form. Using this method the `<input type="file">` stays set upon each POST hence re-uploading the ZIP file, hence it doesn't matter if we switch servers between requests. On the final step it breaks out of the iframe.
